### PR TITLE
fix: needs to be dnf5 instead of dnf due to bazzite restrictions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,8 @@ set -ouex pipefail
 # https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/39/x86_64/repoview/index.html&protocol=https&redirect=1
 
 # this installs a package from fedora repos
-dnf install -y tmux 
-dnf install -y sl
+dnf5 install -y tmux 
+dnf5 install -y sl
 
 # Use a COPR Example:
 #


### PR DESCRIPTION
You got a warning on the actions :sob: This should make the builds green